### PR TITLE
念曹丕【登极】AI修复

### DIFF
--- a/js/precontent/MiNikill.js
+++ b/js/precontent/MiNikill.js
@@ -40309,7 +40309,7 @@ const packs = function () {
                                 const cell = mapState[slot];
 
                                 //角色格子
-                                if (Array.isArray(cell) && cell[0] !== 0) {
+                                if (Array.isArray(cell) && cell[0] !== 0 && curScore > Math.abs(cell[1])) {
                                     pathFound = path.concat([[x, y]]);
                                     targetName = NAMES[cell[0]];
                                     return true;


### PR DESCRIPTION
### PR描述

修复AI进行“登阶”时未校验目标分数，导致分数不足仍可击败角色的问题。