### PR TITLE
修复隐于吉最佳牌型选择

### DIFF
--- a/js/precontent/MiNikill.js
+++ b/js/precontent/MiNikill.js
@@ -44321,44 +44321,9 @@ const packs = function () {
                             return typeof to !== 'number';
                         });
                         next.set('processAI', list => {
-                            const ox = [...list[0][1]], hs = [...list[1][1]], ts = get.event().ts;
-                            let bestOx = ox, bestPool = hs, bestInfo = lib.skill.miniyinyinming.getOXType(ox);
-                            if (lib.skill.miniyinyinming.compareOX(bestInfo, ts) > 0) return [bestOx, bestPool];
-                            for (let maskOut = 1; maskOut < (1 << 5); maskOut++) {
-                                const outIndex = [];
-                                for (let i = 0; i < 5; i++) {
-                                    if (maskOut & (1 << i)) outIndex.push(i);
-                                }
-                                const need = outIndex.length;
-                                const dfs = function (start, chosen) {
-                                    if (chosen.length === need) {
-                                        const newOx = ox.slice();
-                                        const newPool = hs.slice();
-                                        for (let i = 0; i < need; i++) {
-                                            const oxPos = outIndex[i];
-                                            const card = chosen[i];
-                                            newPool.push(newOx[oxPos]);
-                                            newOx[oxPos] = card;
-                                        }
-                                        for (const card of chosen) newPool.remove(card);
-                                        const info = lib.skill.miniyinyinming.getOXType(newOx);
-                                        if (lib.skill.miniyinyinming.compareOX(info, ts) >= 0 && lib.skill.miniyinyinming.compareOX(info, bestInfo) >= 0) {
-                                            bestInfo = info;
-                                            bestOx = newOx;
-                                            bestPool = newPool;
-                                        }
-                                        return;
-                                    }
-                                    for (let i = start; i < hs.length; i++) {
-                                        chosen.push(hs[i]);
-                                        dfs(i + 1, chosen);
-                                        chosen.pop();
-                                    }
-                                }
-                                dfs(0, []);
-                            }
-                            if (lib.skill.miniyinyinming.compareOX(bestInfo, ts) <= 0) return [ox, hs];
-                            return [bestOx, bestPool];
+                            const pool = [...list[0][1], ...list[1][1]];
+                            const cards = lib.skill.miniyinyinming.getBestOX(pool)?.cards ?? [];
+                            return [cards, [...pool].remove(...cards)];
                         });
                         next.set('ts', ts);
                         const func = lib.skill.miniyinyinming.func;
@@ -44559,44 +44524,9 @@ const packs = function () {
                                     return typeof to !== 'number';
                                 });
                                 next.set('processAI', list => {
-                                    const ox = [...list[0][1]], hs = [...list[1][1]], ts = get.event().ts;
-                                    let bestOx = ox, bestPool = hs, bestInfo = lib.skill.miniyinyinming.getOXType(ox);
-                                    if (lib.skill.miniyinyinming.compareOX(bestInfo, ts) > 0) return [bestOx, bestPool];
-                                    for (let maskOut = 1; maskOut < (1 << 5); maskOut++) {
-                                        const outIndex = [];
-                                        for (let i = 0; i < 5; i++) {
-                                            if (maskOut & (1 << i)) outIndex.push(i);
-                                        }
-                                        const need = outIndex.length;
-                                        const dfs = function (start, chosen) {
-                                            if (chosen.length === need) {
-                                                const newOx = ox.slice();
-                                                const newPool = hs.slice();
-                                                for (let i = 0; i < need; i++) {
-                                                    const oxPos = outIndex[i];
-                                                    const card = chosen[i];
-                                                    newPool.push(newOx[oxPos]);
-                                                    newOx[oxPos] = card;
-                                                }
-                                                for (const card of chosen) newPool.remove(card);
-                                                const info = lib.skill.miniyinyinming.getOXType(newOx);
-                                                if (lib.skill.miniyinyinming.compareOX(info, ts) > 0 && lib.skill.miniyinyinming.compareOX(info, bestInfo) > 0) {
-                                                    bestInfo = info;
-                                                    bestOx = newOx;
-                                                    bestPool = newPool;
-                                                }
-                                                return;
-                                            }
-                                            for (let i = start; i < hs.length; i++) {
-                                                chosen.push(hs[i]);
-                                                dfs(i + 1, chosen);
-                                                chosen.pop();
-                                            }
-                                        }
-                                        dfs(0, []);
-                                    }
-                                    if (lib.skill.miniyinyinming.compareOX(bestInfo, ts) <= 0) return [ox, hs];
-                                    return [bestOx, bestPool];
+                                    const pool = [...list[0][1], ...list[1][1]];
+                                    const cards = lib.skill.miniyinyinming.getBestOX(pool)?.cards ?? [];
+                                    return [cards, [...pool].remove(...cards)];
                                 });
                                 next.set('ts', ts);
                                 const func = lib.skill.miniyinyinming.func;


### PR DESCRIPTION
## 修复内容

- 保留了村服特色“炸弹牛”及现有牛牌判定、比较和玩法说明。
- 按官方实现修复了两处换牌场景无法从当前牛牌与手牌中选择全局最佳五张牌的问题。
- 删除了两处重复且受当前胜负状态影响的换牌搜索逻辑，确保“最佳牌型”按钮始终按完整牌池选择最高牌型。

## 验证

- 固定牌例可由牛七正确选择为牛牛。
- 炸弹牛牌型仍可正常识别并参与最佳牌型选择。
- 20,000 组随机牌池的选择结果与暴力枚举一致。
- JavaScript 语法检查通过。