### PR TITLE
修正战吕蒙暗渡弃牌判定

### DIFF
--- a/js/precontent/MiNikill.js
+++ b/js/precontent/MiNikill.js
@@ -43160,7 +43160,7 @@ const packs = function () {
                 filter(event, player) {
                     if (ui._minifightandu_jiangling) return false;
                     if (event.name !== 'phaseDiscard') return true;
-                    return !event.player.hasHistory('lose', evt => evt.getParent('phaseDiscard') == event);
+                    return !event.player.hasHistory('lose', evt => evt.type == 'discard' && evt.getParent('phaseDiscard') == event);
                 },
                 prompt2: `进入“江陵战场”，令所有角色获得${get.poptip('minikeji')}直到其下回合结束`,
                 async content(event, trigger, player) {


### PR DESCRIPTION
## 修复内容

- 修复了“暗渡”将弃牌阶段内非弃牌导致的失牌误判为实际弃牌的问题，现在仅将 `type == 'discard'` 的失牌计为实际弃牌。
- 修复了角色在弃牌阶段因其他效果失牌但未实际弃牌时，“暗渡”被错误阻止触发的问题。

## 验证

- 覆盖“非弃牌失牌仍触发暗渡”和“实际弃牌不触发暗渡”两种情况。
- JavaScript 语法检查通过。