### PR TITLE
修复神郭嘉技能实现

### DIFF
--- a/js/precontent/MiNikill.js
+++ b/js/precontent/MiNikill.js
@@ -34590,10 +34590,10 @@ const packs = function () {
                 ai: {
                     order(item, player) {
                         const event = get.event();
-                        const list = get.inpileVCardList(info => info[0] === 'trick').some(info => {
+                        const list = get.inpileVCardList(info => info[0] === 'trick').filter(info => {
                             if (player.getStorage('minizuoxing_cards').includes(info[2])) return false;
-                            if (!event.filterCard(new lib.element.VCard({ name: info[2], isCard: true }), player, event)) return false;
-                            return player.getUseValue(new lib.element.VCard({ name: info[2], isCard: true })) > 0;
+                            const card = new lib.element.VCard({ name: info[2], isCard: true });
+                            return event.filterCard(card, player, event) && player.getUseValue(card) > 0;
                         });
                         if (!list.length) return 0;
                         const max = Math.max(...list.map(info => player.getUseValue(new lib.element.VCard({ name: info[2], isCard: true }))));
@@ -34617,7 +34617,12 @@ const packs = function () {
                 limited: true,
                 skillAnimation: true,
                 animationColor: 'water',
-                filterTarget: true,
+                filterTarget(card, player, target) {
+                    const list = target.getSkills(null, false, false).filter(skill => {
+                        return !target.awakenedSkills.includes(skill) && lib.skill[skill]?.juexingji;
+                    });
+                    return list.length ? player.maxHp >= game.players.length : player.maxHp >= 3;
+                },
                 selectTarget() {
                     var player = _status.event.player;
                     for (var target of game.filterPlayer()) {
@@ -34627,7 +34632,7 @@ const packs = function () {
                         });
                         var bool1 = (!list.length && player.maxHp >= 3);
                         var bool2 = (list.length && player.maxHp >= game.players.length);
-                        target.prompt((bool1 ? '可摸牌' : '') + ((bool1 && bool2) ? '<br>' : '') + (bool2 ? '可觉醒' : ''));
+                        target.prompt((bool1 ? '可摸牌' : '') + (bool2 ? '可觉醒' : ''));
                     }
                     return 1;
                 },
@@ -34661,7 +34666,7 @@ const packs = function () {
                             const info = lib.skill[skill];
                             info.minihuishi_filter = info.filter;
                             info.filter = function (event, player, ...args) {
-                                if (player.storage.minihuishi_mark) return true;
+                                if (player.storage.minihuishi_mark === skill) return true;
                                 return info.minihuishi_filter.call(this, event, player, ...args);
                             };
                         }, result.control);

--- a/js/precontent/MiNikill.js
+++ b/js/precontent/MiNikill.js
@@ -34632,7 +34632,7 @@ const packs = function () {
                         });
                         var bool1 = (!list.length && player.maxHp >= 3);
                         var bool2 = (list.length && player.maxHp >= game.players.length);
-                        target.prompt((bool1 ? '可摸牌' : '') + (bool2 ? '可觉醒' : ''));
+                        target.prompt(bool1 ? '可摸牌' : bool2 ? '可觉醒' : '不可选择');
                     }
                     return 1;
                 },


### PR DESCRIPTION
## 修改内容
- 修复辉逝可选择不满足发动条件角色的问题
- 将辉逝的觉醒条件放宽限制到指定角色的指定觉醒技，兼容克隆模式
- 修复佐幸 AI 将布尔值误作候选牌数组的问题

## 官方依据
对照《欢乐三国杀》APK 3.10.007：角色 ID 216；技能 1611（HuiShiNew）、4995（ZuoXingTiao）。