### PR TITLE
修复 fork PR 合并后的元数据更新 CI

### DIFF
--- a/.github/workflows/update-after-merge.yml
+++ b/.github/workflows/update-after-merge.yml
@@ -1,7 +1,7 @@
 name: 合并后自动更新file.json和info.json
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [main]
 


### PR DESCRIPTION
## 问题

PR #254 从 fork 合并后，`合并后自动更新file.json和info.json` 工作流在推送更新时返回 403：fork 的 `pull_request` 事件会将 `GITHUB_TOKEN` 强制降为只读，即使工作流声明了 `contents: write`。

## 修复

- 将触发器从 `pull_request` 改为 `pull_request_target`
- 保留 `merged == true` 与 `main` 分支限制
- 继续明确检出可信的 `main`，不执行 fork 中未经信任的代码

这样工作流使用基准仓库上下文获得声明的写权限，可正常提交 `info.json` 和 `js/file.json`。