### PR TITLE
按官方实现修复法正眩惑目标选择

### DIFF
--- a/js/precontent/MiNikill.js
+++ b/js/precontent/MiNikill.js
@@ -9763,7 +9763,7 @@ const packs = function () {
                 trigger: { player: 'phaseDrawBegin1' },
                 async cost(event, trigger, player) {
                     event.result = await player.chooseTarget(get.prompt2('minixuanhuo'), function (card, player, target) {
-                        return player != target;
+                        return player != target && target.countCards('he') > 0;
                     }).set('ai', function (target) {
                         var att = get.attitude(_status.event.player, target);
                         if (target.countCards('he') == 0) return 0;
@@ -9774,7 +9774,8 @@ const packs = function () {
                 async content(event, trigger, player) {
                     const target = event.targets[0];
                     const result = await player.chooseTarget('眩惑：请选择' + get.translation(target) + '出杀的目标', true, function (card, player, target) {
-                        return _status.event.target.canUse('sha', target);
+                        const source = _status.event.target;
+                        return source != target && source.inRange(target);
                     }).set('ai', function (target) {
                         var player = _status.event.player;
                         if (!_status.event.target.canUse('sha', target) && get.attitude(player, _status.event.target) < 0) return 8 + get.attitude(player, target);


### PR DESCRIPTION
## 变更
- 按官方实现修复法正“眩惑”的目标选择限制。
- 首个目标须有可获得的牌；第二目标仅按攻击范围判断，不再受其他【杀】目标合法性条件错误限制。