### PR TITLE
按官方实现修复牌序选择

### DIFF
--- a/js/precontent/MiNikill.js
+++ b/js/precontent/MiNikill.js
@@ -10623,7 +10623,7 @@ const packs = function () {
                         }
                         var cards = list[0][1].slice(0), tops = [];
                         while (tops.length < 4 - _status.event.num) {
-                            list.sort(function (a, b) {
+                            cards.sort(function (a, b) {
                                 return check(b) - check(a);
                             });
                             tops.push(cards.shift());


### PR DESCRIPTION
修复了自动决策错误排序界面分组、未对实际候选牌排序的问题。修复后会按官方实现，根据下一名角色的判定区或用牌价值排序候选牌，并优先选择合适的牌置于牌堆顶。