### PR TITLE
按官方实现修复鸣鸾提示

### DIFF
--- a/js/precontent/MiNikill.js
+++ b/js/precontent/MiNikill.js
@@ -12684,7 +12684,7 @@ const packs = function () {
                     return player != event.player && event.player.isIn() && game.getGlobalHistory('changeHp', evt => evt.getParent().name == 'recover').length && event.player.countCards('h');
                 },
                 prompt(event, player) {
-                    return get.translation('minimingluan') + '（摸' + (event.player.countCards('h')) + '弃' + (player.countCards('h') + event.player.countCards('h') - 5) + '）';
+                    return get.translation('minimingluan') + '（摸' + (event.player.countCards('h')) + '弃' + Math.max(0, player.countCards('h') + event.player.countCards('h') - 5) + '）';
                 },
                 check(event, player) {
                     return player.countCards('h') < 5;


### PR DESCRIPTION
按官方实现修复鸣鸾发动提示，弃牌数不足时显示为 0，避免出现负数，并保留实际需要弃牌时的正确数量。