### PR TITLE
按官方实现修复新一将贾诩完杀封桃失效

### DIFF
--- a/js/precontent/MiNiAppkill.js
+++ b/js/precontent/MiNiAppkill.js
@@ -1977,11 +1977,11 @@ const packs = function () {
                         mod: {
                             cardEnabled(card, player) {
                                 const source = _status.currentPhase;
-                                if (card.name === 'tao' && source?.isIn() && source !== player && source.hasSkill('rewansha') && !player.isDying()) return false;
+                                if (card.name === 'tao' && source?.isIn() && source !== player && source.hasSkill('mpwansha') && !player.isDying()) return false;
                             },
                             cardSavable(card, player) {
                                 const source = _status.currentPhase;
-                                if (card.name === 'tao' && source?.isIn() && source !== player && source.hasSkill('rewansha') && !player.isDying()) return false;
+                                if (card.name === 'tao' && source?.isIn() && source !== player && source.hasSkill('mpwansha') && !player.isDying()) return false;
                             },
                         },
                     },


### PR DESCRIPTION
按官方实现修复新一将贾诩在自己的回合内无法阻止非濒死其他角色使用【桃】的问题，保留本人及濒死角色使用【桃】的规则。

Closes #283